### PR TITLE
Add create-package-json.js and run it in prepack step

### DIFF
--- a/create-package-json.js
+++ b/create-package-json.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const createPackageJson = (type, dir) => {
+  const content = {
+    type: type,
+  };
+  const directory = path.resolve(__dirname, dir);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  fs.writeFileSync(
+    path.join(directory, "package.json"),
+    JSON.stringify(content, null, 2)
+  );
+};
+
+createPackageJson("commonjs", "./dist/cjs");
+createPackageJson("module", "./dist/esm");

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "src"
   ],
   "scripts": {
-    "prepack": "tsc -p tsconfig.browser.esm.json && tsc -p tsconfig.node.cjs.json && tsc -p tsconfig.node.esm.json"
+    "prepack": "tsc -p tsconfig.browser.esm.json && tsc -p tsconfig.node.cjs.json && tsc -p tsconfig.node.esm.json && node ./create-package-json.js"
   },
   "devDependencies": {
     "@types/node": "15.0.1",


### PR DESCRIPTION
An alternative to <https://github.com/jhurliman/just-performance/pull/4>, this fixes <https://github.com/jhurliman/just-performance/issues/3> and <https://github.com/jhurliman/node-rate-limiter/pull/92> with a cross-platform script that outputs package.json files for both CJS and ESM.
