### PR TITLE
package.json: Set "type": "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.4.0",
   "description": "Isomorphic ponyfill wrapping native browser performance and node.js perf_hooks performance",
   "license": "MIT",
+  "type": "module",
   "main": "./dist/cjs/node.js",
   "module": "./dist/esm/node.js",
   "browser": "./dist/esm/browser.js",


### PR DESCRIPTION
Fixes the following warning:

```
[MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///.../node_modules/just-performance/dist/esm/node.js is not specified and it doesn't parse as CommonJS.
```
